### PR TITLE
Add embedded-batteries charger async trait support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ device-driver = { version = "=1.0.0-rc.1", default-features = false, features = 
 defmt = { version = "0.3", optional = true }
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
+embedded-batteries-async = { git = "https://github.com/OpenDevicePartnership/embedded-batteries" }
 
 [dev-dependencies]
 embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,13 @@
 #![cfg_attr(not(test), no_std)]
 #![allow(missing_docs)]
 
+use embedded_batteries_async::charger;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 /// BQ25773 errors
 pub enum BQ25773Error<I2cError> {
-    I2c(I2cError),
+    Bus(I2cError),
 }
 
 const BQ_ADDR: u8 = 0x6B;
@@ -56,7 +58,7 @@ impl<I2c: embedded_hal_async::i2c::I2c> device_driver::AsyncRegisterInterface fo
         self.i2c
             .write(BQ_ADDR, &buf[..=data.len()])
             .await
-            .map_err(BQ25773Error::I2c)
+            .map_err(BQ25773Error::Bus)
     }
 
     async fn read_register(
@@ -68,14 +70,57 @@ impl<I2c: embedded_hal_async::i2c::I2c> device_driver::AsyncRegisterInterface fo
         self.i2c
             .write_read(BQ_ADDR, &[address], data)
             .await
-            .map_err(BQ25773Error::I2c)
+            .map_err(BQ25773Error::Bus)
+    }
+}
+
+impl<E: embedded_hal_async::i2c::Error> charger::Error for BQ25773Error<E> {
+    fn kind(&self) -> charger::ErrorKind {
+        match self {
+            Self::Bus(_) => charger::ErrorKind::CommError,
+        }
+    }
+}
+
+pub struct Bq25773<I2c: embedded_hal_async::i2c::I2c> {
+    pub device: Device<DeviceInterface<I2c>>,
+}
+
+impl<I2c: embedded_hal_async::i2c::I2c> Bq25773<I2c> {
+    pub fn new(i2c: I2c) -> Self {
+        Bq25773 {
+            device: Device::new(DeviceInterface { i2c }),
+        }
+    }
+}
+
+impl<I2c: embedded_hal_async::i2c::I2c> charger::ErrorType for Bq25773<I2c> {
+    type Error = BQ25773Error<I2c::Error>;
+}
+
+impl<I2c: embedded_hal_async::i2c::I2c> charger::Charger for Bq25773<I2c> {
+    async fn charging_current(&mut self, current: charger::MilliAmps) -> Result<charger::MilliAmps, Self::Error> {
+        self.device
+            .charge_current()
+            .write_async(|w| w.set_charge_current(current))
+            .await?;
+        Ok(self.device.charge_current().read_async().await?.charge_current())
+    }
+
+    async fn charging_voltage(&mut self, voltage: charger::MilliVolts) -> Result<charger::MilliVolts, Self::Error> {
+        self.device
+            .charge_voltage()
+            .write_async(|w| w.set_charge_voltage(voltage))
+            .await?;
+        Ok(self.device.charge_voltage().read_async().await?.charge_voltage())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use embedded_batteries_async::charger::Charger;
     use embedded_hal_mock::eh1::i2c::{Mock, Transaction};
-    use field_sets::{ChargeOption2A, ManufactureId};
+    use field_sets::{ChargeCurrent, ChargeOption2A, ManufactureId};
 
     use super::*;
 
@@ -111,5 +156,26 @@ mod tests {
             .unwrap();
 
         bq.interface.i2c.done();
+    }
+
+    #[tokio::test]
+    async fn charging_current_trait_test() {
+        let mut reg = ChargeCurrent::new();
+        // Set charge current to 2000mA
+        reg.set_charge_current(2000);
+        let raw_reg_2a: [u8; 2] = reg.into();
+        let expectations = vec![
+            Transaction::write(BQ_ADDR, vec![0x02, raw_reg_2a[0], raw_reg_2a[1]]),
+            Transaction::write_read(BQ_ADDR, vec![0x02], vec![raw_reg_2a[0], raw_reg_2a[1]]),
+        ];
+        let i2c = Mock::new(&expectations);
+        let mut bq = Bq25773::new(i2c);
+
+        let charge_current = bq.charging_current(2000).await.unwrap();
+
+        // Be sure we get 2000mA back
+        assert_eq!(charge_current, 2000);
+
+        bq.device.interface.i2c.done();
     }
 }


### PR DESCRIPTION
Closes #8 

Cargo.toml will be updated to point at ODP version of repo when https://github.com/OpenDevicePartnership/embedded-batteries/pull/14 goes into ODP/embedded-batteries/main

EDIT: Updated